### PR TITLE
ocp/#deploy-d | Restore correct image names

### DIFF
--- a/tf/modules/services/ida/iam.tf
+++ b/tf/modules/services/ida/iam.tf
@@ -122,8 +122,8 @@ data "aws_iam_policy_document" "ecs_task_execution_policy" {
       "ecr:BatchGetImage",
     ]
     resources = [
-      "arn:aws:ecr:${var.aws_region}:${var.aws_account}:repository/${var.namespace}.proxy",
       "arn:aws:ecr:${var.aws_region}:${var.aws_account}:repository/${var.namespace}.app",
+      "arn:aws:ecr:${var.aws_region}:${var.aws_account}:repository/${var.namespace}.proxy",
     ]
   }
 

--- a/tf/modules/services/ida/main.tf
+++ b/tf/modules/services/ida/main.tf
@@ -92,8 +92,8 @@ locals {
 
 locals {
   images = {
-    proxy = "${local.registry}/${var.namespace}.${local.proxy_name}:${local.tag}",
-    app   = "${local.registry}/${var.namespace}.${local.app_name}:${local.tag}",
+    app   = "${local.registry}/${var.namespace}.app:${local.tag}",
+    proxy = "${local.registry}/${var.namespace}.proxy:${local.tag}",
   }
   protocol = "tcp"
   app_env = [


### PR DESCRIPTION
Get the ecs container names correct.